### PR TITLE
add decimals field to graph

### DIFF
--- a/src/crafana/models/panels/graph.cr
+++ b/src/crafana/models/panels/graph.cr
@@ -22,6 +22,8 @@ module Crafana
 
     property datasource : String?
 
+    property decimals : Int32?
+
     property fill : Int32 = 1
 
     @[JSON::Field(key: "gridPos")]


### PR DESCRIPTION
This allows changing the Grafana `auto` setting for the number of decimal places to something fixed - which I often tend to do.