### PR TITLE
Improves the text panel initializer similar to graph panel

### DIFF
--- a/src/crafana/models/panels/text.cr
+++ b/src/crafana/models/panels/text.cr
@@ -13,9 +13,9 @@ module Crafana
     property mode : String = Crafana::Vars::TEXT_MODE_MARKDOWN
     property span : String?
 
-    def initialize(@dashboard : Crafana::Dashboard, @datasource)
+    def initialize(@dashboard : Crafana::Dashboard? = nil)
       @panel_type = Crafana::Vars::TEXT_TYPE
-      @id = @dashboard.next_panel_id
+      @id = @dashboard.as(Crafana::Dashboard).next_panel_id unless @dashboard.nil?
     end
   end
 end


### PR DESCRIPTION
Since text panel has no datasource property the initializer is currently broken.
Also the dashboard parameter can be optional in graph panel so I copied the same logic here.

Works now on my Grafana :)