### PR TITLE
Remove redundant `grid_pos` property from `Crafana::Graph`

### DIFF
--- a/src/crafana/models/panels/graph.cr
+++ b/src/crafana/models/panels/graph.cr
@@ -29,9 +29,6 @@ module Crafana
     @[JSON::Field(key: "fillGradient")]
     property fill_gradient : Int32 = 0
 
-    @[JSON::Field(key: "gridPos")]
-    property grid_pos : GridPos
-
     @[JSON::Field(key: "isNew")]
     property is_new = true
 


### PR DESCRIPTION
Due to https://github.com/crystal-lang/crystal/pull/9502 this throws an error now compiling with Crystal 0.36.0:
```
In src/crafana/models/panels/graph.cr:32:5

 32 | @[JSON::Field(key: "gridPos")]
      ^
Error: can't annotate @grid_pos in Crafana::Graph because it was first defined in Crafana::Panel
```

I'm not aware of any downsides of removing this duplicate definition.